### PR TITLE
Point to specific version of git2go

### DIFF
--- a/load_source.go
+++ b/load_source.go
@@ -3,7 +3,7 @@ package sourcegit
 import (
 	"fmt"
 	"github.com/emptyinterface/sshconfig"
-	"github.com/libgit2/git2go"
+	"gopkg.in/libgit2/git2go.v26"
 	"io/ioutil"
 	"net/url"
 	"os"


### PR DESCRIPTION
The motivation of this PR is that the version of git2go must match the version of libgit2 installed in the build environment. This will allow the build in the main repository to succeed with the Bionic workers as well as allow the tool to be reliably built with a known version of libgit2.